### PR TITLE
Minor fixes to generate SDK from docker image

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@ PING_IDENTITY_DEVOPS_KEY
 
 2. If you have a license for the product put it in the root of the project directory with the name `pingaccess.lic`. This will then be mounted into the container used for SDK generation and will allow the product to be worked with.
 3. If you use the PingAccess image docker older than three months, you must provide a valid license file.
-4. Specify the docker
+4. Specify the docker image tag to VERSION variable in makefile
 
 
 # Installation

--- a/README.MD
+++ b/README.MD
@@ -13,13 +13,13 @@ To work with the SDK generator there are two ways you can work with the licensed
 ```
 PING_IDENTITY_DEVOPS_USER
 PING_IDENTITY_DEVOPS_KEY
-PING_IDENTITY_DEVOPS_REGISTRY
-PING_IDENTITY_DEVOPS_TAG
 ```
 
 `PING_IDENTITY_DEVOPS_USER` and `PING_IDENTITY_DEVOPS_KEY` are available upon request [here](https://bit.ly/ping-devops-request).
 
 2. If you have a license for the product put it in the root of the project directory with the name `pingaccess.lic`. This will then be mounted into the container used for SDK generation and will allow the product to be worked with.
+3. If you use the PingAccess image docker older than three months, you must provide a valid license file.
+4. Specify the docker
 
 
 # Installation
@@ -54,7 +54,12 @@ make generate
 
 To do this against a dockerised version of Ping Access run the following:
 
+1. Specify the docker image tag to VERSION variable in makefile
+2. Run the following commands
+
 ```bash
+export PING_IDENTITY_DEVOPS_USER=<Ping Identity DevOps User>
+export PING_IDENTITY_DEVOPS_KEY=<Ping Identity DevOps Key>
 make docker-generate
 ```
 

--- a/src/docker_generate.py
+++ b/src/docker_generate.py
@@ -66,7 +66,7 @@ class Container:
             self.logger.info("Found product license, using pingaccess.lic")
             run_args["volumes"] = {
                 license_path: {
-                    "bind": "/opt/in/instance/server/default/conf/pingaccess.lic",
+                    "bind": "/opt/out/instance/conf/pingaccess.lic",
                     "mode": "rw"
                 }
             }

--- a/src/docker_generate.py
+++ b/src/docker_generate.py
@@ -14,7 +14,7 @@ parser = argparse.ArgumentParser(description='PyLogger Generator')
 
 def add_args():
     parser.add_argument(
-        'version', type=str, choices=["6.3.3-edge", "7.0.2-edge", "7.0.3-edge", "edge"],
+        'version', type=str, choices=["6.3.3-edge", "7.0.3-edge", "edge"],
         default="edge", help='Ping Access Version'
     )
 


### PR DESCRIPTION
The fixes are:
- Corrected license file location
- Removed 7.0.2-edge that is unavailable in Docker Hub
- Updated docker-generate instruction