### PR TITLE
(fix) Update parameters for Models in src/templates/apis.j2

### DIFF
--- a/src/templates/apis.j2
+++ b/src/templates/apis.j2
@@ -37,7 +37,7 @@ class {{ safe_class_name(class_name) }}:
         """
         try:
             response = self.session.{{ operation.method.lower() }}(
-{% if operation.has_payload() %}{% for parameter in operation.parameters %}{% if parameter.param_type == 'body' %}                data=dumps({{ parameter.safe_name }}.to_dict(True)),
+{% if operation.has_payload() %}{% for parameter in operation.parameters %}{% if parameter.param_type == 'body' %}                data=dumps({{ parameter.safe_name }}.to_dict({{ parameter.safe_name }})),
 {% endif %}{% endfor %}{% endif %}
 {% if operation.method == 'POST' %}{% for parameter in operation.parameters %}{% if parameter.json_type == 'File' %}
                 files={'file': open({{ parameter.name }}, "rb")},


### PR DESCRIPTION
### Description

The APIs that are generated are consuming the Models using `Model.to_dict(True)`. This fails when the Model is expecting specific attributes that are required for this Model to operate. This change will allow for all attributes to be passed to the API when constructing a Model.

### Current state
```
    def addApplicationCommand(self, Application: ModelApplicationView) -> ModelApplicationView:
        """ Add an Application
        """
        try:
            response = self.session.post(
                data=dumps(Application.to_dict(True)),
                url=self._build_uri("/applications"),
                headers={"Content-Type": "application/json"}
            )
```
#### Output:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "py-ping-access-sdk/pingaccesssdk/models/application_view.py", line 218, in to_dict
    for k, v in self.__dict__.items():
AttributeError: 'bool' object has no attribute '__dict__'
```
### New state
```
    def addApplicationCommand(self, Application: ModelApplicationView) -> ModelApplicationView:
        """ Add an Application
        """
        try:
            response = self.session.post(
                data=dumps(Application.to_dict(Application)),
                url=self._build_uri("/applications"),
                headers={"Content-Type": "application/json"}
            )
```
#### Output:
```
>>> ModelApplicationView = ModelApplicationView(agentId=0, authenticationChallengePolicyId="101", contextRoot="root", defaultAuthType="DefaultAuthTypeView", name="application_test", sidebandClientId="0", siteId=0, spaSupportEnabled=False, virtualHostIds=["1", "2"])
>>> ModelApplicationView.to_dict(ModelApplicationView)
{'agentId': 0, 'authenticationChallengePolicyId': '101', 'contextRoot': 'root', 'defaultAuthType': 'DefaultAuthTypeView', 'name': 'application_test', 'sidebandClientId': '0', 'siteId': 0, 'spaSupportEnabled': False, 'virtualHostIds': ['1', '2']}
```